### PR TITLE
[#7]Refactor: 로컬 경로 변수 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -37,6 +38,8 @@ dependencies {
 
 	//Swagger 관련
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/config/WebConfig.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/config/WebConfig.java
@@ -1,15 +1,20 @@
 package capstone.SportyUp.SportyUp_Server.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${local-path.result}")
+    private String resultPath;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/processed-files/**")
-                .addResourceLocations("file:C:/Users/EliteBook/Documents/GitHub/Back/src/main/resources/cam_after_flask/");
+                .addResourceLocations("file:"+resultPath);
 //        registry.addResourceHandler("/Test/**") 바탕화면에서 테스트
 //                .addResourceLocations("file:C:/Users/EliteBook/Desktop/");
     }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/BowlingService/BowlingCommandServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/BowlingService/BowlingCommandServiceImpl.java
@@ -5,6 +5,7 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.BowlingDTO.BowlingRequestDTO;
 import capstone.SportyUp.SportyUp_Server.web.DTO.BowlingDTO.BowlingResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -24,8 +25,12 @@ import java.nio.file.Files;
 public class BowlingCommandServiceImpl implements BowlingCommandService {
 
     private final String FLASK_SERVER_URL = "http://127.0.0.1:5000";  // Flask 서버 URL (예시: http://localhost:5000)
-    private static final String UPLOAD_DIR = "C:\\Users\\EliteBook\\Documents\\GitHub\\Back\\src\\main\\resources\\cam\\"; // 업로드된 파일 저장 폴더
-    private static final String UPLOAD_RESULT_DIR = "C:\\Users\\EliteBook\\Documents\\GitHub\\Back\\src\\main\\resources\\cam_after_flask\\";
+    @Value("${local-path.windows.upload}")
+    private String UPLOAD_DIR;
+//    private static final String UPLOAD_DIR = "C:\\Users\\EliteBook\\Documents\\GitHub\\Back\\src\\main\\resources\\cam\\"; // 업로드된 파일 저장 폴더
+    @Value("${local-path.windows.result}")
+    private String UPLOAD_RESULT_DIR;
+//    private static final String UPLOAD_RESULT_DIR = "C:\\Users\\EliteBook\\Documents\\GitHub\\Back\\src\\main\\resources\\cam_after_flask\\";
 
     private BowlingConverter bowlingConverter;
 


### PR DESCRIPTION
## 📝 작업 내용
> 로컬 경로명을 String변수에 직접 넣지 않고 yml파일에 넣어서 사용할 수 있도록 수정
> 노션에 yml 파일 업데이트 함.


## 🔍 테스트 방법
> 1. 노션에 있는 yml 파일로 변경한다.
> 2. 사진에 있는 부분을 자신의 로컬 경로에 맞게 변경한다
> <img width="305" alt="image" src="https://github.com/user-attachments/assets/777db2a4-2d69-4421-a92c-216dbac81304" />
>
> 파일을 저장할때 사용되는 윈도우 전용 경로명과 Config 파일에서 사용되는 경로 형식이 달라서 두가지로 만들었다.
>
> 3. 일반적인 경로 사용하기
> <img width="191" alt="image" src="https://github.com/user-attachments/assets/23e33189-b6c9-4cfd-ab22-8e6c1cb598d4" />
>
> @Value("${local-path.result}") 어노테이션을 사용하여 파이썬코드 분석 결과가 저장되는 경로명을 넣으면 된다.
>
>  4. 윈도우 경로 사용하기
> <img width="770" alt="image" src="https://github.com/user-attachments/assets/ac6dd5bd-3ad0-45ae-b512-870e6eaf1467" />
> 똑같이 @Value를 사용하면 된다.
> 주석처리된 부분은 기존에 직접 String변수에 넣는 방법
> 
> 5. 실행해보고 기존과 똑같이 제대로 작동하는지 확인

