### PR TITLE
[#31] Feat: 캘린더 탭 조회 API

### DIFF
--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/GameConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/GameConverter.java
@@ -3,6 +3,7 @@ package capstone.SportyUp.SportyUp_Server.converter;
 import capstone.SportyUp.SportyUp_Server.domain.Game;
 import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,5 +43,16 @@ public class GameConverter {
             result.add(dto);
         }
         return result;
+    }
+
+    public static GameResponseDTO.GameDateListDTO toGameDateListDTO(List<Game> gameList){
+        List<LocalDate> dateList = new ArrayList<>();
+        for(Game game : gameList){
+            dateList.add(game.getPlayDate().toLocalDate());
+        }
+
+        return GameResponseDTO.GameDateListDTO.builder()
+                .gameDateList(dateList)
+                .build();
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/GameRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/GameRepository.java
@@ -2,6 +2,8 @@ package capstone.SportyUp.SportyUp_Server.repository;
 
 import capstone.SportyUp.SportyUp_Server.domain.Game;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,5 +12,20 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findByUserIdAndSportsId(Long userId, Long sportsId);
 
     List<Game> findTop6ByUserIdAndSportsIdOrderByPlayDateDesc(Long userId, Long sportsId);  //최신순 6개게임
+
+    @Query("SELECT g FROM Game g WHERE g.user.id = :userId AND g.sports.id = :sportsId AND YEAR(g.playDate) = :year AND MONTH(g.playDate) = :month ORDER BY g.playDate DESC")
+    List<Game> findByUserIdAndSportsIdAndYearAndMonth(
+            @Param("userId") Long userId,
+            @Param("sportsId") Long sportsId,
+            @Param("year") Integer year,
+            @Param("month") Integer month
+    );
+
+    @Query("SELECT g FROM Game g WHERE g.user.id = :userId AND YEAR(g.playDate) = :year AND MONTH(g.playDate) = :month ORDER BY g.playDate DESC")
+    List<Game> findByUserIdAndYearAndMonth(
+            @Param("userId") Long userId,
+            @Param("year") Integer year,
+            @Param("month") Integer month
+    );
 }
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
@@ -5,4 +5,5 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 public interface GameQueryService {
     public GameResponseDTO.ChartDTO getChart(Long userId, Long sportsId);
     public GameResponseDTO.GameDateListDTO getGameDateListAllCategory(Long userId, Integer year, Integer month);
+    public GameResponseDTO.GameDateListDTO getGameDateListOneCategory(Long userId, Integer year, Integer month, Long sportsId);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
@@ -4,4 +4,5 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 
 public interface GameQueryService {
     public GameResponseDTO.ChartDTO getChart(Long userId, Long sportsId);
+    public GameResponseDTO.GameDateListDTO getGameDateListAllCategory(Long userId, Integer year, Integer month);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
@@ -9,7 +9,10 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class GameQueryServiceImpl implements GameQueryService {
@@ -47,5 +50,24 @@ public class GameQueryServiceImpl implements GameQueryService {
         long gameCount = gameList.size();
 
         return GameConverter.toChartDTO(gameCount, averageScore, highScore, lowScore, currentGameList);
+    }
+
+    @Override
+    public GameResponseDTO.GameDateListDTO getGameDateListAllCategory(Long userId, Integer year, Integer month) {
+        User user = userRepository.findById(userId).orElse(null);   //Todo: 유저 확인
+        List<Game> gameList = gameRepository.findByUserIdAndYearAndMonth(userId,year,month);
+
+        // playDate 기준으로 날짜(LocalDate) 중복 제거
+        List<Game> distinctByDate = gameList.stream()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                game -> game.getPlayDate().toLocalDate(), // 날짜만 key로 사용
+                                game -> game,
+                                (existing, replacement) -> existing // 중복 시 첫 번째 것 유지
+                        ),
+                        map -> new ArrayList<>(map.values())
+                ));
+
+        return GameConverter.toGameDateListDTO(distinctByDate);
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
@@ -70,4 +70,23 @@ public class GameQueryServiceImpl implements GameQueryService {
 
         return GameConverter.toGameDateListDTO(distinctByDate);
     }
+
+    @Override
+    public GameResponseDTO.GameDateListDTO getGameDateListOneCategory(Long userId, Integer year, Integer month, Long sportsId) {
+        User user = userRepository.findById(userId).orElse(null);   //Todo: 유저 확인
+        List<Game> gameList = gameRepository.findByUserIdAndSportsIdAndYearAndMonth(userId,sportsId,year,month);
+
+        // playDate 기준으로 날짜(LocalDate) 중복 제거
+        List<Game> distinctByDate = gameList.stream()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                game -> game.getPlayDate().toLocalDate(), // 날짜만 key로 사용
+                                game -> game,
+                                (existing, replacement) -> existing // 중복 시 첫 번째 것 유지
+                        ),
+                        map -> new ArrayList<>(map.values())
+                ));
+
+        return GameConverter.toGameDateListDTO(distinctByDate);
+    }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
@@ -28,7 +28,8 @@ public class GameController implements GameSpecification {
 
     @Override
     public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListAllCategory(Long userId, Integer year, Integer month) {
-        return null;
+
+        return ApiResponse.onSuccess(gameQueryService.getGameDateListAllCategory(userId,year,month));
     }
 
     @Override

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
@@ -27,7 +27,12 @@ public class GameController implements GameSpecification {
     }
 
     @Override
-    public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateList(Integer year, Integer month, String sports) {
+    public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListAllCategory(Long userId, Integer year, Integer month) {
+        return null;
+    }
+
+    @Override
+    public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(Long userId, Integer year, Integer month) {
         return null;
     }
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
@@ -33,8 +33,9 @@ public class GameController implements GameSpecification {
     }
 
     @Override
-    public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(Long userId, Integer year, Integer month) {
-        return null;
+    public ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(Long userId, Integer year, Integer month, Long sportsId) {
+
+        return ApiResponse.onSuccess(gameQueryService.getGameDateListOneCategory(userId,year,month,sportsId));
     }
 
     @Override

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
@@ -32,7 +32,7 @@ public interface GameSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "날짜가 잘못되었습니다.")
     })
-    ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(@RequestParam Long userId, @RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(@RequestParam Long userId, @RequestParam Integer year, @RequestParam Integer month, @PathVariable Long sportsId);
 
 
     @GetMapping("/{gameId}")

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
@@ -19,12 +19,21 @@ public interface GameSpecification {
     ApiResponse<GameResponseDTO.GameInfoListDTO> getGameList(@RequestParam LocalDate date, @RequestParam String sports);
 
     @GetMapping("/dates")
-    @Operation(summary = "캘린더 탭 조회 API", description = "달력에서 게임이 진행된 날짜를 표시하기 위한 API입니다. QueryString으로 year와 month, sports 필요")
+    @Operation(summary = "캘린더 탭 조회(전체종목) API", description = "달력에서 전체종목으로 게임이 진행된 날짜를 표시하기 위한 API입니다. QueryString으로 year와 month 필요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "날짜가 잘못되었습니다.")
     })
-    ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateList(@RequestParam Integer year, @RequestParam Integer month, @RequestParam String sports);
+    ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListAllCategory(@RequestParam Long userId, @RequestParam Integer year, @RequestParam Integer month);
+
+    @GetMapping("/dates/{sportsId}")
+    @Operation(summary = "캘린더 탭 조회(한 개 종목) API", description = "달력에서 한 종목으로 게임이 진행된 날짜를 표시하기 위한 API입니다. QueryString으로 year와 month 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "날짜가 잘못되었습니다.")
+    })
+    ApiResponse<GameResponseDTO.GameDateListDTO> getGameDateListOneCategory(@RequestParam Long userId, @RequestParam Integer year, @RequestParam Integer month);
+
 
     @GetMapping("/{gameId}")
     @Operation(summary = "게임 조회 API", description = "게임 하나를 조회하는 API입니다. PathVariable로 gameId 필요")


### PR DESCRIPTION
## 📝 작업 내용
> 캘린더 조회 시
> 1. 전체 종목 조회 -> 모든 종목으로 진행한 게임이 있는 날짜 응답
> 2. 한 종목 조회  -> 한 종목으로 진행한 게임이 있는 날짜 응


## 🔍 테스트 방법
1. 전체 종목 조회
<img width="848" alt="image" src="https://github.com/user-attachments/assets/153d9f43-f167-4170-9aac-4fa62299eae9" />
1-1. 확인
<img width="841" alt="image" src="https://github.com/user-attachments/assets/f83e5368-8884-4eec-9f40-3c31f62e38a9" />
2. 한 종목 조회 - 볼링의 sportsId가 1 
<img width="849" alt="image" src="https://github.com/user-attachments/assets/a41eb835-c525-4213-acb0-0d5426e8f282" />
2-1. 확인
<img width="845" alt="image" src="https://github.com/user-attachments/assets/a2642317-1434-497a-9489-1c04b89edc5a" />
3. 한 종목 조회2 - sportsId를 2로 요청
<img width="850" alt="image" src="https://github.com/user-attachments/assets/d4001684-41dc-462d-9709-b2906b5f65c0" />
3-1. 확인 - 다른 종목으로 게임이 없어서 빈 리스트가 응답으로 옴
<img width="847" alt="image" src="https://github.com/user-attachments/assets/b2a7a37d-06a5-40ba-b76a-1feaaae6a131" />

