### PR TITLE
[#35]Feat: 게임 리스트 조회 API 구현

### DIFF
--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/GameConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/GameConverter.java
@@ -55,4 +55,21 @@ public class GameConverter {
                 .gameDateList(dateList)
                 .build();
     }
+
+    public static GameResponseDTO.GameInfoListDTO toGameInfoListDTO(List<Game> gameList){
+        List<GameResponseDTO.GameInfoDTO> result = new ArrayList<>();
+        for(Game game : gameList){
+            result.add(GameResponseDTO.GameInfoDTO.builder()
+                    .id(game.getId())
+                    .sportsId(game.getSports().getId())
+                    .score(game.getScore())
+                    .playDate(game.getPlayDate())
+                    .build());
+        }
+
+        return GameResponseDTO.GameInfoListDTO.builder()
+                .gameInfoList(result)
+                .build();
+
+    }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/GameRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/GameRepository.java
@@ -27,5 +27,23 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month
     );
+
+    @Query("SELECT g FROM Game g WHERE g.user.id = :userId AND YEAR(g.playDate) = :year AND MONTH(g.playDate) = :month AND DAY(g.playDate) = :day ORDER BY g.playDate DESC")
+    List<Game> findByUserIdAndPlayDate(
+            @Param("userId") Long userId,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("day") Integer day
+    );
+
+    @Query("SELECT g FROM Game g WHERE g.user.id = :userId AND g.sports.id = :sportsId AND YEAR(g.playDate) = :year AND MONTH(g.playDate) = :month AND DAY(g.playDate) = :day ORDER BY g.playDate DESC")
+    List<Game> findByUserIdAndSportsIdAndPlayDate(
+            @Param("userId") Long userId,
+            @Param("sportsId") Long sportsId,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("day") Integer day
+    );
+
 }
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryService.java
@@ -2,8 +2,12 @@ package capstone.SportyUp.SportyUp_Server.service.GameService;
 
 import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 
+import java.time.LocalDate;
+
 public interface GameQueryService {
     public GameResponseDTO.ChartDTO getChart(Long userId, Long sportsId);
     public GameResponseDTO.GameDateListDTO getGameDateListAllCategory(Long userId, Integer year, Integer month);
     public GameResponseDTO.GameDateListDTO getGameDateListOneCategory(Long userId, Integer year, Integer month, Long sportsId);
+    public GameResponseDTO.GameInfoListDTO getGameListAllCategory(Long userId, LocalDate date);
+    public GameResponseDTO.GameInfoListDTO getGameListOneCategory(Long userId, LocalDate date, Long sportsId);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/GameService/GameQueryServiceImpl.java
@@ -9,6 +9,7 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.GameDTO.GameResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -88,5 +89,32 @@ public class GameQueryServiceImpl implements GameQueryService {
                 ));
 
         return GameConverter.toGameDateListDTO(distinctByDate);
+    }
+
+    @Override
+    public GameResponseDTO.GameInfoListDTO getGameListAllCategory(Long userId, LocalDate date) {
+
+        User user = userRepository.findById(userId).orElse(null);
+        Integer year = date.getYear();
+        Integer month = date.getMonthValue();
+        Integer day = date.getDayOfMonth();
+
+        List<Game> gameList = gameRepository.findByUserIdAndPlayDate(userId, year, month, day);
+
+
+        return GameConverter.toGameInfoListDTO(gameList);
+    }
+
+    @Override
+    public GameResponseDTO.GameInfoListDTO getGameListOneCategory(Long userId, LocalDate date, Long sportsId) {
+
+        User user = userRepository.findById(userId).orElse(null);
+        Integer year = date.getYear();
+        Integer month = date.getMonthValue();
+        Integer day = date.getDayOfMonth();
+
+        List<Game> gameList = gameRepository.findByUserIdAndSportsIdAndPlayDate(userId, sportsId, year, month, day);
+
+        return GameConverter.toGameInfoListDTO(gameList);
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/GameDTO/GameResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/GameDTO/GameResponseDTO.java
@@ -25,8 +25,8 @@ public class GameResponseDTO {
     @AllArgsConstructor
     public static class GameInfoDTO{
         Long id;        //게임 번호
-        String sports;  //스포츠 종목
-        LocalDate playDate; //게임 진행 날짜
+        Long sportsId;  //스포츠 종목
+        LocalDateTime playDate; //게임 진행 날짜
         Integer score;  //점수
     }
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/GameController.java
@@ -22,8 +22,15 @@ public class GameController implements GameSpecification {
     private final GameQueryService gameQueryService;
 
     @Override
-    public ApiResponse<GameResponseDTO.GameInfoListDTO> getGameList(LocalDate date, String sports) {
-        return null;
+    public ApiResponse<GameResponseDTO.GameInfoListDTO> getGameListAllCategory(Long userId, LocalDate date) {
+
+        return ApiResponse.onSuccess(gameQueryService.getGameListAllCategory(userId, date));
+    }
+
+    @Override
+    public ApiResponse<GameResponseDTO.GameInfoListDTO> getGameListOneCategory(Long userId, LocalDate date, Long sportsId) {
+
+        return ApiResponse.onSuccess(gameQueryService.getGameListOneCategory(userId, date, sportsId));
     }
 
     @Override

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/GameSpecification.java
@@ -11,12 +11,19 @@ import java.time.LocalDate;
 
 public interface GameSpecification {
 
-    @GetMapping("")
-    @Operation(summary = "게임 리스트 조회 API", description = "한 날짜에 진행된 게임들의 리스트를 보여주는 API입니다. QueryString으로 date, sports 필요")
+    @GetMapping("/list")
+    @Operation(summary = "게임 리스트 조회(전체종목) API", description = "한 날짜에 진행된 전체종목 게임들의 리스트를 보여주는 API입니다. QueryString으로 date필요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    ApiResponse<GameResponseDTO.GameInfoListDTO> getGameList(@RequestParam LocalDate date, @RequestParam String sports);
+    ApiResponse<GameResponseDTO.GameInfoListDTO> getGameListAllCategory(@RequestParam Long userId, @RequestParam LocalDate date);
+
+    @GetMapping("/{sportsId}/list")
+    @Operation(summary = "게임 리스트 조회(한 개 종목) API", description = "한 날짜에 진행된 전체종목 게임들의 리스트를 보여주는 API입니다. QueryString으로 date필요, PathVariable로 sportsId 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    ApiResponse<GameResponseDTO.GameInfoListDTO> getGameListOneCategory(@RequestParam Long userId, @RequestParam LocalDate date, @PathVariable Long sportsId);
 
     @GetMapping("/dates")
     @Operation(summary = "캘린더 탭 조회(전체종목) API", description = "달력에서 전체종목으로 게임이 진행된 날짜를 표시하기 위한 API입니다. QueryString으로 year와 month 필요")


### PR DESCRIPTION
## 📝 작업 내용
> 게임 리스트 조회 API 구현
> - 전체 종목으로 조회
> - 한 종목으로 조회


## 🔍 테스트 방법
1. 전체 종목 조회
<img width="850" alt="image" src="https://github.com/user-attachments/assets/e04354fd-fa04-4bcd-8d02-4a3a0d076f62" />
1-1. 확인
<img width="848" alt="image" src="https://github.com/user-attachments/assets/feb6ca58-b03b-4650-8913-efed1fd7de16" />
2. 한 종목으로 조회
<img width="851" alt="image" src="https://github.com/user-attachments/assets/bad2daff-3267-4b21-b6c7-c50f9aa36a88" />
2-1. 확인
<img width="844" alt="image" src="https://github.com/user-attachments/assets/c5dea827-8939-4f6e-a656-bfa4aebcd90c" />
