### PR TITLE
[#43] Feat: 인증번호 전송, 인증 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//Swagger 관련
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	//coolSMS - 문자 전송 서비스
 	implementation group: 'net.nurigo', name: 'javaSDK', version: '2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	//Swagger 관련
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	//coolSMS - 문자 전송 서비스
+	implementation group: 'net.nurigo', name: 'javaSDK', version: '2.2'
+
 
 }
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/AuthHandler.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/AuthHandler.java
@@ -1,0 +1,9 @@
+package capstone.SportyUp.SportyUp_Server.apiPayload.Exception;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.BaseErrorCode;
+
+public class AuthHandler extends GeneralException {
+    public AuthHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/GeneralException.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/GeneralException.java
@@ -1,0 +1,21 @@
+package capstone.SportyUp.SportyUp_Server.apiPayload.Exception;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.BaseErrorCode;
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package capstone.SportyUp.SportyUp_Server.apiPayload.Exception;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.ErrorReasonDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ErrorReasonDTO> handleGeneralException(GeneralException e) {
+        return ResponseEntity
+                .status(e.getErrorReasonHttpStatus().getHttpStatus())
+                .body(e.getErrorReasonHttpStatus());
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    //인증 관련 에러
+    AUTH_CODE_NOT_FOUND(HttpStatus.FORBIDDEN, "AUTH4001", "인증번호나 전화번호를 찾을 수 없습니다."),
+    AUTH_ALREADY_VERIFIED(HttpStatus.FORBIDDEN, "AUTH4002", "이미 완료된 인증입니다."),
+    AUTH_CODE_MISMATCH(HttpStatus.FORBIDDEN, "AUTH4003", "인증번호가 일치하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
@@ -1,11 +1,18 @@
 package capstone.SportyUp.SportyUp_Server.converter;
 
+import capstone.SportyUp.SportyUp_Server.domain.SmsVerification;
 import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
 
 public class AuthConverter {
-    public static AuthResponseDTO.SmsSendResultDTO toSmsSendResultDTO(){
+    public static AuthResponseDTO.SmsSendResultDTO toSmsSendResultDTO(SmsVerification smsVerification){
         return AuthResponseDTO.SmsSendResultDTO.builder()
-                .message("문자 전송 완료")
+                .phoneNum(smsVerification.getPhoneNum())
+                .build();
+    }
+
+    public static AuthResponseDTO.SmsVerifyResultDTO toSmsVerifyResultDTO(SmsVerification smsVerification){
+        return AuthResponseDTO.SmsVerifyResultDTO.builder()
+                .code(smsVerification.getVerificationCode())
                 .build();
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
@@ -1,0 +1,11 @@
+package capstone.SportyUp.SportyUp_Server.converter;
+
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+
+public class AuthConverter {
+    public static AuthResponseDTO.SmsSendResultDTO toSmsSendResultDTO(){
+        return AuthResponseDTO.SmsSendResultDTO.builder()
+                .message("문자 전송 완료")
+                .build();
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/AuthConverter.java
@@ -12,6 +12,7 @@ public class AuthConverter {
 
     public static AuthResponseDTO.SmsVerifyResultDTO toSmsVerifyResultDTO(SmsVerification smsVerification){
         return AuthResponseDTO.SmsVerifyResultDTO.builder()
+                .phoneNum(smsVerification.getPhoneNum())
                 .code(smsVerification.getVerificationCode())
                 .build();
     }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/SmsVerification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/SmsVerification.java
@@ -1,0 +1,32 @@
+package capstone.SportyUp.SportyUp_Server.domain;
+
+import capstone.SportyUp.SportyUp_Server.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SmsVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "phone_number", nullable = false, length = 20)
+    private String phoneNum;
+
+    @Column(name = "verification_code", nullable = false, length = 10)
+    private String verificationCode;
+
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified = false;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/SmsVerification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/SmsVerification.java
@@ -25,7 +25,7 @@ public class SmsVerification extends BaseEntity {
     private String verificationCode;
 
     @Column(name = "is_verified", nullable = false)
-    private boolean isVerified = false;
+    private boolean verified = false;
 
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
@@ -1,0 +1,7 @@
+package capstone.SportyUp.SportyUp_Server.repository;
+
+import capstone.SportyUp.SportyUp_Server.domain.SmsVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SmsVerificationRepository extends JpaRepository<SmsVerification, Long> {
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
@@ -3,5 +3,10 @@ package capstone.SportyUp.SportyUp_Server.repository;
 import capstone.SportyUp.SportyUp_Server.domain.SmsVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 public interface SmsVerificationRepository extends JpaRepository<SmsVerification, Long> {
+    //전화번호, 유효기간이 지금 이후, 인증상태가 false인 엔티티 찾기
+    Optional<SmsVerification> findByPhoneNumAndExpiresAtAfterAndVerifiedIsFalse(String phoneNum, LocalDateTime currentDateTime);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsService.java
@@ -1,0 +1,9 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+
+public interface CoolSmsService {
+    public AuthResponseDTO.SmsSendResultDTO sendSms(AuthRequestDTO.SmsSendDTO request) throws CoolsmsException;
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsServiceImpl.java
@@ -58,7 +58,7 @@ public class CoolSmsServiceImpl implements CoolSmsService {
 
         smsVerificationRepository.save(smsVerification);
 
-        return AuthConverter.toSmsSendResultDTO();
+        return AuthConverter.toSmsSendResultDTO(smsVerification);
     }
 
     // 랜덤한 4자리 숫자 생성 메서드

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CoolSmsServiceImpl.java
@@ -1,0 +1,74 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.converter.AuthConverter;
+import capstone.SportyUp.SportyUp_Server.domain.SmsVerification;
+import capstone.SportyUp.SportyUp_Server.repository.SmsVerificationRepository;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.java_sdk.api.Message;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class CoolSmsServiceImpl implements CoolSmsService {
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String apiSecret;
+
+    @Value("${coolsms.api.number}")
+    private String fromPhoneNumber;
+
+    private final SmsVerificationRepository smsVerificationRepository;
+
+    public AuthResponseDTO.SmsSendResultDTO sendSms(AuthRequestDTO.SmsSendDTO request) throws CoolsmsException {
+        // 랜덤한 4자리 인증번호 생성
+        String numStr = generateRandomNumber();
+        String userPhoneNum = request.getPhoneNum();
+
+        try {
+            Message coolsms = new Message(apiKey, apiSecret); // 생성자를 통해 API 키와 API 시크릿 전달
+
+            HashMap<String, String> params = new HashMap<>();
+            params.put("to", userPhoneNum);    // 수신 전화번호
+            params.put("from", fromPhoneNumber);    // 발신 전화번호
+            params.put("type", "sms");
+            params.put("text", "[SportyUP]\n 인증번호 : " + numStr);
+
+            // 메시지 전송
+            coolsms.send(params);
+
+        } catch (Exception e) {
+            throw new CoolsmsException("Failed to send SMS", e.hashCode());
+        }
+
+        SmsVerification smsVerification = SmsVerification.builder()
+                .phoneNum(userPhoneNum)
+                .verificationCode(numStr)
+                .expiresAt(LocalDateTime.now().plusMinutes(3))  //현재부터 3분뒤 만료
+                .build(); // 생성된 인증번호 반환
+
+        smsVerificationRepository.save(smsVerification);
+
+        return AuthConverter.toSmsSendResultDTO();
+    }
+
+    // 랜덤한 4자리 숫자 생성 메서드
+    private String generateRandomNumber() {
+        Random rand = new Random();
+        StringBuilder numStr = new StringBuilder();
+        for (int i = 0; i < 4; i++) {
+            numStr.append(rand.nextInt(10));
+        }
+        return numStr.toString();
+    }
+
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/VerifyService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/VerifyService.java
@@ -1,0 +1,8 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+
+public interface VerifyService {
+    public AuthResponseDTO.SmsVerifyResultDTO verifySms(AuthRequestDTO.SmsVerifyDTO request);
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/VerifyServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/VerifyServiceImpl.java
@@ -1,0 +1,38 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.Exception.AuthHandler;
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.status.ErrorStatus;
+import capstone.SportyUp.SportyUp_Server.converter.AuthConverter;
+import capstone.SportyUp.SportyUp_Server.domain.SmsVerification;
+import capstone.SportyUp.SportyUp_Server.repository.SmsVerificationRepository;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyServiceImpl implements VerifyService {
+
+    private final SmsVerificationRepository smsVerificationRepository;
+
+    @Override
+    @Transactional
+    public AuthResponseDTO.SmsVerifyResultDTO verifySms(AuthRequestDTO.SmsVerifyDTO request) {
+        SmsVerification smsVerification = smsVerificationRepository
+                .findByPhoneNumAndExpiresAtAfterAndVerifiedIsFalse(request.getPhoneNum(), LocalDateTime.now())
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.AUTH_CODE_NOT_FOUND));
+
+        if(smsVerification.getVerificationCode().equals(request.getCode())){    //사용자 입력과 코드가 일치하는 경우
+            smsVerification.setVerified(true);
+
+            return AuthConverter.toSmsVerifyResultDTO(smsVerification);
+        }else{
+            throw new AuthHandler(ErrorStatus.AUTH_CODE_MISMATCH);
+        }
+
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthRequestDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthRequestDTO.java
@@ -16,4 +16,16 @@ public class AuthRequestDTO {
         @NotNull
         String phoneNum;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SmsVerifyDTO{
+        @NotNull
+        String phoneNum;
+
+        @NotNull
+        String code;
+    }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthRequestDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthRequestDTO.java
@@ -1,0 +1,19 @@
+package capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class AuthRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SmsSendDTO{
+        @NotNull
+        String phoneNum;
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
@@ -6,11 +6,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class AuthResponseDTO {
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SmsSendResultDTO{
-        String message;
+        private String phoneNum;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SmsVerifyResultDTO{
+        private String code;
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
@@ -20,6 +20,7 @@ public class AuthResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SmsVerifyResultDTO{
+        private String phoneNum;
         private String code;
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/AuthDTO/AuthResponseDTO.java
@@ -1,0 +1,16 @@
+package capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SmsSendResultDTO{
+        String message;
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/AuthController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/AuthController.java
@@ -1,0 +1,28 @@
+package capstone.SportyUp.SportyUp_Server.web.controller;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.ApiResponse;
+import capstone.SportyUp.SportyUp_Server.service.AuthService.CoolSmsService;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+import capstone.SportyUp.SportyUp_Server.web.controller.specification.AuthSpecification;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController implements AuthSpecification {
+
+    private final CoolSmsService coolSmsService;
+
+    @Override
+    public ApiResponse<AuthResponseDTO.SmsSendResultDTO> sendSms(AuthRequestDTO.SmsSendDTO request){
+        try {
+            return ApiResponse.onSuccess(coolSmsService.sendSms(request));
+        } catch (CoolsmsException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/AuthController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/AuthController.java
@@ -2,6 +2,7 @@ package capstone.SportyUp.SportyUp_Server.web.controller;
 
 import capstone.SportyUp.SportyUp_Server.apiPayload.ApiResponse;
 import capstone.SportyUp.SportyUp_Server.service.AuthService.CoolSmsService;
+import capstone.SportyUp.SportyUp_Server.service.AuthService.VerifyService;
 import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
 import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
 import capstone.SportyUp.SportyUp_Server.web.controller.specification.AuthSpecification;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthSpecification {
 
     private final CoolSmsService coolSmsService;
+    private final VerifyService verifyService;
 
     @Override
     public ApiResponse<AuthResponseDTO.SmsSendResultDTO> sendSms(AuthRequestDTO.SmsSendDTO request){
@@ -24,5 +26,11 @@ public class AuthController implements AuthSpecification {
         } catch (CoolsmsException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public ApiResponse<AuthResponseDTO.SmsVerifyResultDTO> verifySms(AuthRequestDTO.SmsVerifyDTO request) {
+
+        return ApiResponse.onSuccess(verifyService.verifySms(request));
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/AuthSpecification.java
@@ -1,0 +1,20 @@
+package capstone.SportyUp.SportyUp_Server.web.controller.specification;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.ApiResponse;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.AuthDTO.AuthResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface AuthSpecification {
+
+    @PostMapping("/sms/send")
+    @Operation(summary = "인증번호 전송 API", description = "사용자 인증을 위한 인증번호 전송 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    ApiResponse<AuthResponseDTO.SmsSendResultDTO> sendSms(@RequestBody AuthRequestDTO.SmsSendDTO request) throws CoolsmsException;
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/AuthSpecification.java
@@ -17,4 +17,11 @@ public interface AuthSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     ApiResponse<AuthResponseDTO.SmsSendResultDTO> sendSms(@RequestBody AuthRequestDTO.SmsSendDTO request) throws CoolsmsException;
+
+    @PostMapping("/sms/verification")
+    @Operation(summary = "인증번호 인증 API", description = "사용자 인증을 위한 인증번호 확인 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    ApiResponse<AuthResponseDTO.SmsVerifyResultDTO> verifySms(@RequestBody AuthRequestDTO.SmsVerifyDTO request);
 }


### PR DESCRIPTION
## 📝 작업 내용
> 인증번호 전송, 인증 API 구현


## 🔍 테스트 방법
1. 인증번호 전송 요청 - 자기 전화번호 입력
<img width="956" alt="image" src="https://github.com/user-attachments/assets/bc11b3c9-0b28-49a9-aea7-4b4e38eb01ad" />
<img width="946" alt="image" src="https://github.com/user-attachments/assets/e1fd8700-1879-4262-b3bc-30e02d8363c2" />

2. 폰에 문자 오는지 확인

<img width="557" alt="image" src="https://github.com/user-attachments/assets/e56c96b0-7c92-49b8-b63d-1eb5c5ab6773" />

3. 인증번호 인증 요청 - 자기 번호와 문자로 온 인증번호 입력
<img width="956" alt="image" src="https://github.com/user-attachments/assets/b137a12c-2be7-4244-a4f6-bdc7a74ced21" />
<img width="955" alt="image" src="https://github.com/user-attachments/assets/85057f4e-e8cd-49da-821e-5dd91fcb6634" />




