### PR TITLE
[#45]Feat: 이메일 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
@@ -41,6 +41,11 @@ dependencies {
 
 	//coolSMS - 문자 전송 서비스
 	implementation group: 'net.nurigo', name: 'javaSDK', version: '2.2'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/UserHandler.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/UserHandler.java
@@ -1,0 +1,9 @@
+package capstone.SportyUp.SportyUp_Server.apiPayload.Exception;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.BaseErrorCode;
+
+public class UserHandler extends GeneralException {
+    public UserHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
@@ -19,7 +19,13 @@ public enum ErrorStatus implements BaseErrorCode {
     //인증 관련 에러
     AUTH_CODE_NOT_FOUND(HttpStatus.FORBIDDEN, "AUTH4001", "인증번호나 전화번호를 찾을 수 없습니다."),
     AUTH_ALREADY_VERIFIED(HttpStatus.FORBIDDEN, "AUTH4002", "이미 완료된 인증입니다."),
-    AUTH_CODE_MISMATCH(HttpStatus.FORBIDDEN, "AUTH4003", "인증번호가 일치하지 않습니다.");
+    AUTH_CODE_MISMATCH(HttpStatus.FORBIDDEN, "AUTH4003", "인증번호가 일치하지 않습니다."),
+    AUTH_REQUIRED_VERIFICATION(HttpStatus.FORBIDDEN, "AUTH4003", "전화번호 인증이 필요합니다."),
+
+    //유저 관련 에러
+    USER_DUPLICATE_EMAIL(HttpStatus.FORBIDDEN, "USER4001", "이메일이 중복됩니다."),
+    USER_EMAIL_NOT_FOUND(HttpStatus.FORBIDDEN, "USER4002", "이메일이 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/config/SecurityConfig.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package capstone.SportyUp.SportyUp_Server.config;
+
+import capstone.SportyUp.SportyUp_Server.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**",
+                                "/users/email",
+                                "/users/kakao",
+                                "/users/naver"
+                                ).permitAll()    //회원가입, 로그인, 스웨거 화면은 허용
+                        .anyRequest().authenticated()   //나머지는 인증 필요
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/converter/UserConverter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/converter/UserConverter.java
@@ -1,0 +1,12 @@
+package capstone.SportyUp.SportyUp_Server.converter;
+
+import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
+
+public class UserConverter {
+    public static UserResponseDTO.SignUpResultDTO toSignUpResultDTO(String accessToken, String refreshToken) {
+        return UserResponseDTO.SignUpResultDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/RefreshToken.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/RefreshToken.java
@@ -1,0 +1,28 @@
+package capstone.SportyUp.SportyUp_Server.domain;
+
+import capstone.SportyUp.SportyUp_Server.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String token;
+
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/User.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/User.java
@@ -5,6 +5,7 @@ import capstone.SportyUp.SportyUp_Server.domain.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,7 +23,7 @@ public class User extends BaseEntity {
     @Column(unique = true, length = 50, nullable = false)
     private String email;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 100, nullable = false)
     private String password;
 
     @Column(length = 20, nullable = false)
@@ -30,6 +31,8 @@ public class User extends BaseEntity {
 
     @Column(length = 50, nullable = false)
     private String phoneNum;
+
+    private LocalDate birthday;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -41,4 +44,7 @@ public class User extends BaseEntity {
 
     private String backgroundImgUrl;
 
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package capstone.SportyUp.SportyUp_Server.filter;
+
+import capstone.SportyUp.SportyUp_Server.service.AuthService.CustomUserDetailsService;
+import capstone.SportyUp.SportyUp_Server.service.AuthService.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        //Bearer 토큰 존재 여부 확인
+        if(authHeader == null || !authHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7); //"Bearer " 이후 토큰 부분
+        String email = jwtService.extractEmail(token);  //토큰에서 이메일 복원
+
+        if(email != null && SecurityContextHolder.getContext().getAuthentication() == null){
+            var userDetails = userDetailsService.loadUserByUsername(email);
+
+            if(jwtService.isTokenValid(token, userDetails)){
+                var authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/SmsVerificationRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface SmsVerificationRepository extends JpaRepository<SmsVerification, Long> {
     //전화번호, 유효기간이 지금 이후, 인증상태가 false인 엔티티 찾기
     Optional<SmsVerification> findByPhoneNumAndExpiresAtAfterAndVerifiedIsFalse(String phoneNum, LocalDateTime currentDateTime);
+    Optional<SmsVerification> findTop1ByPhoneNumAndVerifiedIsTrueOrderByCreatedAtDesc(String phoneNum);
+
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/UserRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/UserRepository.java
@@ -3,6 +3,10 @@ package capstone.SportyUp.SportyUp_Server.repository;
 import capstone.SportyUp.SportyUp_Server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CustomUserDetailsService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.Exception.UserHandler;
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.status.ErrorStatus;
+import capstone.SportyUp.SportyUp_Server.domain.User;
+import capstone.SportyUp.SportyUp_Server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_EMAIL_NOT_FOUND));
+
+        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), List.of());
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/JwtService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/AuthService/JwtService.java
@@ -1,0 +1,81 @@
+package capstone.SportyUp.SportyUp_Server.service.AuthService;
+
+import capstone.SportyUp.SportyUp_Server.domain.RefreshToken;
+import capstone.SportyUp.SportyUp_Server.domain.User;
+import capstone.SportyUp.SportyUp_Server.repository.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    @Value("${spring.jwt.secretKey}")
+    private String secretKey;
+    private final long accessTokenExpirationMs = 1000 * 60 * 60; //AccessToken만료시간 1시간
+    private final long refreshTokenExpirationMs = 1000L * 60 * 60 * 24 * 7; //7일
+    private final UserRepository userRepository;
+
+    public String createAccessToken(Long userId, String email){
+        return Jwts.builder()
+                .setSubject("AccessToken")
+                .claim("userId", userId)
+                .claim("email", email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis()+accessTokenExpirationMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId){
+
+        return Jwts.builder()
+                .setSubject("RefreshToken")
+                .claim("userId", userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis()+refreshTokenExpirationMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public void saveRefreshToken(User user, String token){
+        RefreshToken refreshToken = RefreshToken.builder()
+                .user(user)
+                .token(token)
+                .expiredAt(LocalDateTime.now().plus(Duration.ofMillis(refreshTokenExpirationMs)))
+                .build();
+    }
+
+    public String extractEmail(String token){
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails){
+        String email = extractEmail(token);
+
+        return email.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token){
+        Date expiration = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+
+        return expiration.before(new Date());
+    }
+
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandService.java
@@ -1,0 +1,8 @@
+package capstone.SportyUp.SportyUp_Server.service.UserService;
+
+import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
+
+public interface UserCommandService {
+    public UserResponseDTO.SignUpResultDTO emailSignUp(UserRequestDTO.SingUpDTO request);
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandServiceImpl.java
@@ -1,0 +1,56 @@
+package capstone.SportyUp.SportyUp_Server.service.UserService;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.Exception.AuthHandler;
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.status.ErrorStatus;
+import capstone.SportyUp.SportyUp_Server.converter.UserConverter;
+import capstone.SportyUp.SportyUp_Server.domain.User;
+import capstone.SportyUp.SportyUp_Server.domain.enums.UserStatus;
+import capstone.SportyUp.SportyUp_Server.repository.SmsVerificationRepository;
+import capstone.SportyUp.SportyUp_Server.repository.UserRepository;
+import capstone.SportyUp.SportyUp_Server.service.AuthService.JwtService;
+import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserRequestDTO;
+import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final SmsVerificationRepository smsVerificationRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    @Override
+    public UserResponseDTO.SignUpResultDTO emailSignUp(UserRequestDTO.SingUpDTO request) {
+        //해당 전화번호 인증된 기록이 있는지 확인
+        if(!smsVerificationRepository
+                .findTop1ByPhoneNumAndVerifiedIsTrueOrderByCreatedAtDesc(request.getPhoneNum())
+                .isPresent()) throw new AuthHandler(ErrorStatus.AUTH_REQUIRED_VERIFICATION);
+
+        //유저 생성
+        User newUser = User.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .phoneNum(request.getPhoneNum())
+                .birthday(request.getBirthday())
+                .status(UserStatus.ACTIVE)
+                .name(request.getNickname())
+                .build();
+
+        userRepository.save(newUser);
+
+        //JWT 토큰 발급
+        String accessToken = jwtService.createAccessToken(newUser.getId(), newUser.getEmail());
+        String refreshToken = jwtService.createRefreshToken(newUser.getId());
+        //RefreshToken 토큰 저장
+        jwtService.saveRefreshToken(newUser, refreshToken);
+
+
+        return UserConverter.toSignUpResultDTO(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
@@ -5,25 +5,23 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.time.LocalDate;
+
 public class UserRequestDTO {
 
     @Getter
     @Setter
-    public static class JoinDTO{
+    public static class SingUpDTO{
         @NotBlank
         private String email;
         @NotBlank
         private String password;
         @NotBlank
-        private String name;
+        private String nickname;
         @NotBlank
-        private String phone_num;
+        private String phoneNum;
         @NotBlank
-        private String prefer_sports;
-        @NotBlank
-        private String level;
-        @NotBlank
-        private String goal;
+        private LocalDate birthday;
     }
 
 

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
@@ -20,16 +20,17 @@ public class UserResponseDTO {
         @NotBlank
         private String password;
         @NotBlank
-        private String phone_num;
+        private String phoneNum;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class JoinResultDTO{
+    public static class SignUpResultDTO{
         @NotBlank
-        private String id;
-
+        private String accessToken;
+        @NotBlank
+        private String refreshToken;
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/UserController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/UserController.java
@@ -1,6 +1,7 @@
 package capstone.SportyUp.SportyUp_Server.web.controller;
 
 import capstone.SportyUp.SportyUp_Server.apiPayload.ApiResponse;
+import capstone.SportyUp.SportyUp_Server.service.UserService.UserCommandService;
 import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserRequestDTO;
 import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
 import capstone.SportyUp.SportyUp_Server.web.controller.specification.UserSpecification;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController implements UserSpecification {
+    private final UserCommandService userCommandService;
     @Override
     public ApiResponse<UserResponseDTO.UserInfoDTO> getUserInfo() {
         return null;
@@ -23,17 +25,18 @@ public class UserController implements UserSpecification {
     }
 
     @Override
-    public ApiResponse<UserResponseDTO.JoinResultDTO> emailSignUp(UserRequestDTO.JoinDTO request) {
+    public ApiResponse<UserResponseDTO.SignUpResultDTO> emailSignUp(UserRequestDTO.SingUpDTO request) {
+
+        return ApiResponse.onSuccess(userCommandService.emailSignUp(request));
+    }
+
+    @Override
+    public ApiResponse<UserResponseDTO.SignUpResultDTO> kakaoSignUp(UserRequestDTO.SingUpDTO request) {
         return null;
     }
 
     @Override
-    public ApiResponse<UserResponseDTO.JoinResultDTO> kakaoSignUp(UserRequestDTO.JoinDTO request) {
-        return null;
-    }
-
-    @Override
-    public ApiResponse<UserResponseDTO.JoinResultDTO> naverSignUp(UserRequestDTO.JoinDTO request) {
+    public ApiResponse<UserResponseDTO.SignUpResultDTO> naverSignUp(UserRequestDTO.SingUpDTO request) {
         return null;
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/UserSpecification.java
@@ -36,7 +36,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "잘못된 사용자 정보입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "이미 등록된 사용자입니다.")
     })
-    ApiResponse<UserResponseDTO.JoinResultDTO> emailSignUp(@RequestBody UserRequestDTO.JoinDTO request);
+    ApiResponse<UserResponseDTO.SignUpResultDTO> emailSignUp(@RequestBody UserRequestDTO.SingUpDTO request);
 
     @PostMapping("/kakao")
     @Operation(summary = "카카오 회원가입 API", description = "카카오로 회원가입하는 API, RequestBody에 회원가입에 입력한 사용자 정보를 보내주세요")
@@ -45,7 +45,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "잘못된 사용자 정보입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "이미 등록된 사용자입니다.")
     })
-    ApiResponse<UserResponseDTO.JoinResultDTO> kakaoSignUp(@RequestBody UserRequestDTO.JoinDTO request);
+    ApiResponse<UserResponseDTO.SignUpResultDTO> kakaoSignUp(@RequestBody UserRequestDTO.SingUpDTO request);
 
     @PostMapping("/naver")
     @Operation(summary = "네이버 회원가입 API", description = "네이버로 회원가입하는 API, RequestBody에 회원가입에 입력한 사용자 정보를 보내주세요")
@@ -54,7 +54,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "잘못된 사용자 정보입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "이미 등록된 사용자입니다.")
     })
-    ApiResponse<UserResponseDTO.JoinResultDTO> naverSignUp(@RequestBody UserRequestDTO.JoinDTO request);
+    ApiResponse<UserResponseDTO.SignUpResultDTO> naverSignUp(@RequestBody UserRequestDTO.SingUpDTO request);
 
 
 


### PR DESCRIPTION
## 📝 작업 내용
> 이메일 회원가입 구현
> 전화번호 인증 후 이메일 회원가입


## 🔍 테스트 방법
1. 전화번호 인증을 안 했을 경우
<img width="950" alt="image" src="https://github.com/user-attachments/assets/77e977f2-913b-4125-b1a3-7dcc2fee2096" />
2. 전화번호 인증을 했을 경우
<img width="958" alt="image" src="https://github.com/user-attachments/assets/271e9399-7765-46cd-b4de-46c46274f459" />
3. 응답확인 - 발급된 AccessToken을 헤더에 담아 다른 API 요청
<img width="958" alt="image" src="https://github.com/user-attachments/assets/c04e3f64-b75d-43e6-8717-339dc016489a" />

