### PR TITLE
[#53] Feat: 설문조사 API구현 

### DIFF
--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/SportsHandler.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/Exception/SportsHandler.java
@@ -1,0 +1,9 @@
+package capstone.SportyUp.SportyUp_Server.apiPayload.Exception;
+
+import capstone.SportyUp.SportyUp_Server.apiPayload.code.BaseErrorCode;
+
+public class SportsHandler extends GeneralException {
+    public SportsHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/apiPayload/code/status/ErrorStatus.java
@@ -29,7 +29,10 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.FORBIDDEN, "USER4004", "사용자를 찾을 수 없습니다."),
 
     //토큰관련 에러
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.FORBIDDEN, "TOKEN4001", "refresh token을 찾을 수 없습니다..");
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.FORBIDDEN, "TOKEN4001", "refresh token을 찾을 수 없습니다."),
+
+    //스포츠 관련 에러
+    SPORTS_NOT_FOUND(HttpStatus.FORBIDDEN, "SPORTS4001", "스포츠 종목을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/User.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/User.java
@@ -48,6 +48,7 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+
     public void encodePassword(String password) {
         this.password = password;
     }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/UserSports.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/UserSports.java
@@ -2,6 +2,7 @@ package capstone.SportyUp.SportyUp_Server.domain;
 
 import capstone.SportyUp.SportyUp_Server.domain.common.BaseEntity;
 import capstone.SportyUp.SportyUp_Server.domain.enums.UserSportsGoal;
+import capstone.SportyUp.SportyUp_Server.domain.enums.UserSportsLevel;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -18,10 +19,13 @@ public class UserSports extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int level;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserSportsLevel level;   //현재 실력
 
-
-    private UserSportsGoal goal;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserSportsGoal goal;    //본인 목표
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/enums/UserSportsGoal.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/enums/UserSportsGoal.java
@@ -1,5 +1,5 @@
 package capstone.SportyUp.SportyUp_Server.domain.enums;
 
 public enum UserSportsGoal {
-    GENERAL, AMATEUR, PROFESSIONAL  //초급, 중급, 고급
+    GENERAL, AMATEUR, PROFESSIONAL  //일반, 아마추어, 프로
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/domain/enums/UserSportsLevel.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/domain/enums/UserSportsLevel.java
@@ -1,0 +1,5 @@
+package capstone.SportyUp.SportyUp_Server.domain.enums;
+
+public enum UserSportsLevel {
+    BEGINNER, INTERMEDIATE, ADVANCED    //초급, 중급, 고급
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/repository/UserSportsRepository.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/repository/UserSportsRepository.java
@@ -1,0 +1,7 @@
+package capstone.SportyUp.SportyUp_Server.repository;
+
+import capstone.SportyUp.SportyUp_Server.domain.UserSports;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSportsRepository extends JpaRepository<UserSports, Long> {
+}

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandService.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandService.java
@@ -6,4 +6,5 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
 public interface UserCommandService {
     public UserResponseDTO.SignUpResultDTO emailSignUp(UserRequestDTO.SingUpDTO request);
     public UserResponseDTO.LoginResultDTO emailLogin(UserRequestDTO.LoginDTO request);
+    public void surveyUser(Long userId, UserRequestDTO.SurveyDTO request);
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/service/UserService/UserCommandServiceImpl.java
@@ -1,13 +1,18 @@
 package capstone.SportyUp.SportyUp_Server.service.UserService;
 
+import capstone.SportyUp.SportyUp_Server.apiPayload.Exception.SportsHandler;
 import capstone.SportyUp.SportyUp_Server.apiPayload.Exception.UserHandler;
 import capstone.SportyUp.SportyUp_Server.apiPayload.code.status.ErrorStatus;
 import capstone.SportyUp.SportyUp_Server.converter.UserConverter;
+import capstone.SportyUp.SportyUp_Server.domain.Sports;
 import capstone.SportyUp.SportyUp_Server.domain.User;
+import capstone.SportyUp.SportyUp_Server.domain.UserSports;
 import capstone.SportyUp.SportyUp_Server.domain.enums.Role;
 import capstone.SportyUp.SportyUp_Server.domain.enums.UserStatus;
 import capstone.SportyUp.SportyUp_Server.repository.SmsVerificationRepository;
+import capstone.SportyUp.SportyUp_Server.repository.SportsRepository;
 import capstone.SportyUp.SportyUp_Server.repository.UserRepository;
+import capstone.SportyUp.SportyUp_Server.repository.UserSportsRepository;
 import capstone.SportyUp.SportyUp_Server.service.AuthService.JwtService;
 import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserRequestDTO;
 import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
@@ -23,6 +28,8 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     private final SmsVerificationRepository smsVerificationRepository;
     private final UserRepository userRepository;
+    private final SportsRepository sportsRepository;
+    private final UserSportsRepository userSportsRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
 
@@ -74,5 +81,20 @@ public class UserCommandServiceImpl implements UserCommandService {
         jwtService.refreshTokenUpdate(user, refreshToken);
 
         return UserConverter.toLoginResultDTO(accessToken,refreshToken);
+    }
+
+    @Override
+    public void surveyUser(Long userId, UserRequestDTO.SurveyDTO request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        Sports sports = sportsRepository.findById(request.getSportsId()).orElseThrow(() -> new SportsHandler(ErrorStatus.SPORTS_NOT_FOUND));
+
+        UserSports userSports = UserSports.builder()
+                .user(user)
+                .sports(sports)
+                .level(request.getLevel())
+                .goal(request.getGoal())
+                .build();
+
+        userSportsRepository.save(userSports);
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
@@ -1,5 +1,7 @@
 package capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO;
 
+import capstone.SportyUp.SportyUp_Server.domain.enums.UserSportsGoal;
+import capstone.SportyUp.SportyUp_Server.domain.enums.UserSportsLevel;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -64,6 +66,15 @@ public class UserRequestDTO {
     @Setter
     public static class SurveyDTO{
         @NotBlank
-        private String preferSports;
+        private Long sportsId;
+
+        @NotBlank
+        private String usageReason;
+
+        @NotBlank
+        private UserSportsLevel level;
+
+        @NotBlank
+        private UserSportsGoal goal;
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserRequestDTO.java
@@ -59,4 +59,11 @@ public class UserRequestDTO {
         @NotBlank
         private String password;
     }
+
+    @Getter
+    @Setter
+    public static class SurveyDTO{
+        @NotBlank
+        private String preferSports;
+    }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
@@ -50,7 +50,8 @@ public class UserResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SurveyResultDTO{
-
+        @NotBlank
+        private String message;
     }
 
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/DTO/UserDTO/UserResponseDTO.java
@@ -44,4 +44,13 @@ public class UserResponseDTO {
         @NotBlank
         private String refreshToken;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SurveyResultDTO{
+
+    }
+
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/UserController.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/UserController.java
@@ -6,6 +6,8 @@ import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserRequestDTO;
 import capstone.SportyUp.SportyUp_Server.web.DTO.UserDTO.UserResponseDTO;
 import capstone.SportyUp.SportyUp_Server.web.controller.specification.UserSpecification;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,5 +40,15 @@ public class UserController implements UserSpecification {
     @Override
     public ApiResponse<UserResponseDTO.SignUpResultDTO> naverSignUp(UserRequestDTO.SingUpDTO request) {
         return null;
+    }
+
+    @Override
+    public ApiResponse surveyUser(UserRequestDTO.SurveyDTO request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        userCommandService.surveyUser(userId, request);
+
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/capstone/SportyUp/SportyUp_Server/web/controller/specification/UserSpecification.java
@@ -56,6 +56,12 @@ public interface UserSpecification {
     })
     ApiResponse<UserResponseDTO.SignUpResultDTO> naverSignUp(@RequestBody UserRequestDTO.SingUpDTO request);
 
-
-
+    @PatchMapping("/survey")
+    @Operation(summary = "설문조사 API", description = "관심 종목, 앱 사용 이유, 실력과 목표를 설문조사 내용을 저장하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "사용자가 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "잘못된 사용자 정보입니다.")
+    })
+    ApiResponse<UserResponseDTO.SurveyResultDTO> surveyUser(@RequestBody  UserRequestDTO.SurveyDTO request);
 }


### PR DESCRIPTION
## 📝 작업 내용
> 설문조사 API 구현하였습니다.
> 설문조사 내용을 보내주면 해당 내용으로 UserSports 테이블에 엔티티를 생성합니다.
> 설문조사 내용 중 **앱 사용 이유** 의 경우 어느 부분에 저장할 지 의논해야할 것 같습니다.
> 우선 관심 종목, 실력, 목표만 저장하였습니다.


## 🔍 테스트 방법
1. 스웨거 요청
<img width="970" alt="image" src="https://github.com/user-attachments/assets/f35ab482-13e4-42a1-8b5f-0d2882c096d2" />

2. 응답
<img width="956" alt="image" src="https://github.com/user-attachments/assets/c27a012c-b4a3-4863-a925-f155c3d76633" />

3. DB 확인
```
select * from user_sports;
```
<img width="474" alt="image" src="https://github.com/user-attachments/assets/6939b289-7189-4d97-a185-26bce4eeee53" />
